### PR TITLE
fix: prevent audio crackle when returning to tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,25 @@ export default function App() {
     return () => clearBreathTimeout();
   }, [breathe, clearBreathTimeout]);
 
+  useEffect(() => {
+    function handleVisibilityChange() {
+      if (document.hidden) {
+        clearBreathTimeout();
+        setPhaseIndex(-1);
+        setText("ready");
+        setCircleScale(0.25);
+        firstCycleRef.current = true;
+      } else {
+        clearBreathTimeout();
+        breatheTimeoutRef.current = setTimeout(() => breathe(settings), 4000);
+      }
+    }
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [settings, breathe, clearBreathTimeout]);
+
   // Set background accent color based on phase
   useEffect(() => {
     if (playful.dynamicColorsEnabled && phaseIndex >= 0) {


### PR DESCRIPTION
## Summary

Sometimes when switching back to the tab from another app, a brief crackle/click would play. Two compounding causes:

1. **AudioContext auto-suspends** when the tab is hidden, cutting off any in-flight oscillator without a fade.
2. **Chained `setTimeout`s in the breathing loop get throttled** while hidden. On return, the pending callbacks fire in a burst, scheduling multiple overlapping `playPhaseSound()` calls during the AudioContext resume transient — producing the crackle.

## Fix

Add a `visibilitychange` listener in `App.tsx`:
- On hidden: clear the breathe timeout and reset the UI to idle (`phaseIndex = -1`, text "ready", circle scale 0.25, reset `firstCycleRef`).
- On visible: re-schedule `breathe(settings)` with the same 4s intro delay used on fresh mount.

This eliminates both root causes — nothing is in flight to be cut off, and no timer burst fires on return.

## Test plan

- [x] Load the app, enable sound, let the cycle run
- [x] Simulate `visibilitychange` to hidden → UI resets to "ready", timers cleared
- [x] Simulate `visibilitychange` to visible → after ~4s, breathing cycle restarts cleanly
- [x] No console errors
- [x] Manual smoke test with actual tab switching across varying durations (1s, 5s, 30s)
- [x] Verify initial page load behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)