### PR TITLE
Store settings in Firestore for authenticated users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import {
   savePlayfulSettings,
   PHASE_COLORS,
 } from "./types";
+import { loadUserSettings, saveUserSettings } from "./firestore";
+import { useAuth } from "./auth/AuthContext";
 import { playPhaseSound, playMilestoneSound } from "./audio";
 import SideMenu from "./components/SideMenu";
 import Circle from "./components/Circle";
@@ -15,6 +17,7 @@ import CycleCounter from "./components/CycleCounter";
 import Particles from "./components/Particles";
 
 export default function App() {
+  const { user } = useAuth();
   const [settings, setSettings] = useState<Setting[]>(loadSettings);
   const [playful, setPlayful] = useState<PlayfulSettings>(loadPlayfulSettings);
   const [text, setText] = useState("ready");
@@ -26,6 +29,26 @@ export default function App() {
   const breatheTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const playfulRef = useRef(playful);
   playfulRef.current = playful;
+
+  useEffect(() => {
+    if (!user) return;
+    loadUserSettings(user.uid).then((data) => {
+      if (data?.settings) {
+        setSettings(data.settings);
+        window.localStorage.setItem("settings", JSON.stringify(data.settings));
+      }
+      if (data?.playfulSettings) {
+        setPlayful(data.playfulSettings);
+        savePlayfulSettings(data.playfulSettings);
+      }
+      if (!data) {
+        saveUserSettings(user.uid, {
+          settings: loadSettings(),
+          playfulSettings: loadPlayfulSettings(),
+        });
+      }
+    });
+  }, [user?.uid]);
 
   const clearBreathTimeout = useCallback(() => {
     if (breatheTimeoutRef.current !== null) {
@@ -127,6 +150,7 @@ export default function App() {
 
   function handleSettingsChange(newSettings: Setting[]) {
     setSettings(newSettings);
+    if (user) saveUserSettings(user.uid, { settings: newSettings });
     clearBreathTimeout();
     setCycleCount(0);
     setPhaseIndex(-1);
@@ -137,11 +161,13 @@ export default function App() {
   function handlePlayfulChange(newPlayful: PlayfulSettings) {
     setPlayful(newPlayful);
     savePlayfulSettings(newPlayful);
+    if (user) saveUserSettings(user.uid, { playfulSettings: newPlayful });
   }
 
   return (
     <>
       <SideMenu
+        settings={settings}
         onSettingsChange={handleSettingsChange}
         playfulSettings={playful}
         onPlayfulChange={handlePlayfulChange}

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -5,7 +5,6 @@ import {
   Setting,
   PlayfulSettings,
   DEFAULT_SETTINGS,
-  loadSettings,
   loadNoSleepEnabled,
   saveNoSleepEnabled,
 } from "../types";
@@ -13,19 +12,25 @@ import { useAuth } from "../auth/AuthContext";
 import "./SideMenu.scss";
 
 interface SideMenuProps {
+  settings: Setting[];
   onSettingsChange: (newSettings: Setting[]) => void;
   playfulSettings: PlayfulSettings;
   onPlayfulChange: (settings: PlayfulSettings) => void;
 }
 
 export default function SideMenu({
+  settings,
   onSettingsChange,
   playfulSettings,
   onPlayfulChange,
 }: SideMenuProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [noSleepEnabled, setNoSleepEnabled] = useState(loadNoSleepEnabled);
-  const [formSettings, setFormSettings] = useState<Setting[]>(loadSettings);
+  const [formSettings, setFormSettings] = useState<Setting[]>(settings);
+
+  useEffect(() => {
+    setFormSettings(settings);
+  }, [settings]);
   const [authError, setAuthError] = useState<string | null>(null);
   const [authBusy, setAuthBusy] = useState(false);
 

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp, type FirebaseApp } from "firebase/app";
 import { getAuth, type Auth } from "firebase/auth";
+import { getFirestore, type Firestore } from "firebase/firestore";
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -16,10 +17,12 @@ export const isFirebaseConfigured = Boolean(
 
 let app: FirebaseApp | null = null;
 let auth: Auth | null = null;
+let db: Firestore | null = null;
 
 if (isFirebaseConfigured) {
   app = initializeApp(firebaseConfig);
   auth = getAuth(app);
+  db = getFirestore(app);
 }
 
-export { app, auth };
+export { app, auth, db };

--- a/src/firestore.ts
+++ b/src/firestore.ts
@@ -1,0 +1,19 @@
+import { doc, getDoc, setDoc } from "firebase/firestore";
+import { db } from "./firebase";
+import type { Setting, PlayfulSettings } from "./types";
+
+export interface UserSettings {
+  settings?: Setting[];
+  playfulSettings?: PlayfulSettings;
+}
+
+export async function loadUserSettings(uid: string): Promise<UserSettings | null> {
+  if (!db) return null;
+  const snap = await getDoc(doc(db, "users", uid));
+  return snap.exists() ? (snap.data() as UserSettings) : null;
+}
+
+export async function saveUserSettings(uid: string, data: Partial<UserSettings>): Promise<void> {
+  if (!db) return;
+  await setDoc(doc(db, "users", uid), data, { merge: true });
+}

--- a/src/firestore.ts
+++ b/src/firestore.ts
@@ -2,18 +2,45 @@ import { doc, getDoc, setDoc } from "firebase/firestore";
 import { db } from "./firebase";
 import type { Setting, PlayfulSettings } from "./types";
 
+interface PhaseDoc {
+  word: string;
+  duration: number;
+}
+
+interface UserDoc {
+  settings?: PhaseDoc[];
+  playfulSettings?: PlayfulSettings;
+}
+
 export interface UserSettings {
   settings?: Setting[];
   playfulSettings?: PlayfulSettings;
 }
 
+function serializeSettings(settings: Setting[]): PhaseDoc[] {
+  return settings.map(([word, duration]) => ({ word, duration }));
+}
+
+function deserializeSettings(phases: PhaseDoc[]): Setting[] {
+  return phases.map(({ word, duration }) => [word, duration]);
+}
+
 export async function loadUserSettings(uid: string): Promise<UserSettings | null> {
   if (!db) return null;
   const snap = await getDoc(doc(db, "users", uid));
-  return snap.exists() ? (snap.data() as UserSettings) : null;
+  if (!snap.exists()) return null;
+  const data = snap.data() as UserDoc;
+  return {
+    settings: data.settings ? deserializeSettings(data.settings) : undefined,
+    playfulSettings: data.playfulSettings,
+  };
 }
 
 export async function saveUserSettings(uid: string, data: Partial<UserSettings>): Promise<void> {
   if (!db) return;
-  await setDoc(doc(db, "users", uid), data, { merge: true });
+  const doc_ = doc(db, "users", uid);
+  const payload: Partial<UserDoc> = {};
+  if (data.settings) payload.settings = serializeSettings(data.settings);
+  if (data.playfulSettings) payload.playfulSettings = data.playfulSettings;
+  await setDoc(doc_, payload, { merge: true });
 }


### PR DESCRIPTION
When a user signs in with Google, their breathing phase settings and playful settings are synced to/from a Firestore document at users/{uid}. On first sign-in the current localStorage values are uploaded; on subsequent sign-ins the Firestore values take precedence and are written back to localStorage so the app stays consistent.

Unauthenticated users continue using localStorage only.

https://claude.ai/code/session_01F6ZdMBqxAs26Yu3xyQZqga