### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single-page React/TypeScript breathing meditation app built with Vite.
+
+### Services
+
+| Service | Command | Port |
+|---------|---------|------|
+| Vite Dev Server | `npm run dev -- --port 5174 --host` | 5174 |
+
+### Key commands
+
+- **Dev server**: `npm run dev` (Vite with HMR)
+- **Type check / lint**: `npx tsc --noEmit` (no separate ESLint config; TypeScript strict mode is the linter)
+- **Build**: `npm run build`
+- **Preview production build**: `npm run preview`
+
+### Notes
+
+- Firebase is **optional**. The app degrades gracefully when `VITE_FIREBASE_*` env vars are not set (uses localStorage fallback). No `.env` file is needed to run locally.
+- There is no dedicated test runner or ESLint configuration in this repo. TypeScript strict compilation (`npx tsc --noEmit`) is the primary code quality check.
+- The `.claude/launch.json` specifies port 5174 for the dev server.
+- Cloudflare Wrangler is included as a dependency for production deployment but is not needed for local dev.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

## What's included

- Service table (Vite dev server on port 5174)
- Key commands for type checking, building, and running the dev server
- Notes on Firebase being optional, no ESLint config, and Wrangler not needed for local dev

## Demo

[breathing_app_demo.mp4](https://cursor.com/agents/bc-e2ea055f-6cc6-4cd3-be12-93aee3e2dcae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbreathing_app_demo.mp4)

The app running locally with the breathing animation, settings panel open, and customized timing intervals.

[Breathing animation running](https://cursor.com/agents/bc-e2ea055f-6cc6-4cd3-be12-93aee3e2dcae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbreathing_app_animation.webp)
[Settings panel open](https://cursor.com/agents/bc-e2ea055f-6cc6-4cd3-be12-93aee3e2dcae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbreathing_app_settings.webp)
[Customized breathing phase](https://cursor.com/agents/bc-e2ea055f-6cc6-4cd3-be12-93aee3e2dcae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbreathing_app_customized.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2ea055f-6cc6-4cd3-be12-93aee3e2dcae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2ea055f-6cc6-4cd3-be12-93aee3e2dcae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

