### PR TITLE
Consolidate app settings into a single object

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,14 @@ import BreathingText from "./components/BreathingText";
 import CycleCounter from "./components/CycleCounter";
 import Particles from "./components/Particles";
 
+function phasesEqual(a: Setting[], b: Setting[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i][0] !== b[i][0] || Number(a[i][1]) !== Number(b[i][1])) return false;
+  }
+  return true;
+}
+
 export default function App() {
   const { user } = useAuth();
   const [settings, setSettings] = useState<AppSettings>(loadAppSettings);
@@ -144,14 +152,18 @@ export default function App() {
 
   const handleSettingsChange = useCallback(
     (next: AppSettings) => {
+      const prev = settingsRef.current;
+      const phasesChanged = !phasesEqual(prev.phases, next.phases);
       setSettings(next);
       saveAppSettings(next);
       if (user) saveUserSettings(user.uid, next);
-      clearBreathTimeout();
-      setCycleCount(0);
-      setPhaseIndex(-1);
-      firstCycleRef.current = true;
-      breathe(next.phases);
+      if (phasesChanged) {
+        clearBreathTimeout();
+        setCycleCount(0);
+        setPhaseIndex(-1);
+        firstCycleRef.current = true;
+        breathe(next.phases);
+      }
     },
     [user, breathe, clearBreathTimeout],
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import {
-  Setting,
-  PlayfulSettings,
-  loadSettings,
-  loadPlayfulSettings,
-  savePlayfulSettings,
+  type Setting,
+  AppSettings,
+  loadAppSettings,
+  saveAppSettings,
   PHASE_COLORS,
 } from "./types";
 import { loadUserSettings, saveUserSettings } from "./firestore";
@@ -18,8 +17,7 @@ import Particles from "./components/Particles";
 
 export default function App() {
   const { user } = useAuth();
-  const [settings, setSettings] = useState<Setting[]>(loadSettings);
-  const [playful, setPlayful] = useState<PlayfulSettings>(loadPlayfulSettings);
+  const [settings, setSettings] = useState<AppSettings>(loadAppSettings);
   const [text, setText] = useState("ready");
   const [circleScale, setCircleScale] = useState(0.25);
   const [circleTransition, setCircleTransition] = useState("all 4.0s ease-in-out");
@@ -27,25 +25,18 @@ export default function App() {
   const [cycleCount, setCycleCount] = useState(0);
 
   const breatheTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const playfulRef = useRef(playful);
-  playfulRef.current = playful;
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
 
   useEffect(() => {
     if (!user) return;
     loadUserSettings(user.uid).then((data) => {
-      if (data?.settings) {
-        setSettings(data.settings);
-        window.localStorage.setItem("settings", JSON.stringify(data.settings));
-      }
-      if (data?.playfulSettings) {
-        setPlayful(data.playfulSettings);
-        savePlayfulSettings(data.playfulSettings);
-      }
-      if (!data) {
-        saveUserSettings(user.uid, {
-          settings: loadSettings(),
-          playfulSettings: loadPlayfulSettings(),
-        });
+      if (data) {
+        setSettings(data);
+        saveAppSettings(data);
+      } else {
+        const initial = loadAppSettings();
+        saveUserSettings(user.uid, initial);
       }
     });
   }, [user?.uid]);
@@ -59,8 +50,8 @@ export default function App() {
 
   const firstCycleRef = useRef(true);
 
-  const breathe = useCallback((currentSettings: Setting[], phase = 0) => {
-    const [word, timeStr] = currentSettings[phase];
+  const breathe = useCallback((phases: Setting[], phase = 0) => {
+    const [word, timeStr] = phases[phase];
     const duration = Number(timeStr);
 
     setPhaseIndex(phase);
@@ -72,7 +63,7 @@ export default function App() {
       } else {
         setCycleCount((prev) => {
           const next = prev + 1;
-          if (next > 0 && next % 5 === 0 && playfulRef.current.soundEnabled) {
+          if (next > 0 && next % 5 === 0 && settingsRef.current.soundEnabled) {
             playMilestoneSound();
           }
           return next;
@@ -81,7 +72,7 @@ export default function App() {
     }
 
     // Play phase sound if enabled
-    if (playfulRef.current.soundEnabled && duration > 0) {
+    if (settingsRef.current.soundEnabled && duration > 0) {
       playPhaseSound(phase);
     }
 
@@ -100,12 +91,12 @@ export default function App() {
     }
 
     breatheTimeoutRef.current = setTimeout(() => {
-      breathe(currentSettings, (phase + 1) % currentSettings.length);
+      breathe(phases, (phase + 1) % phases.length);
     }, duration * 1000);
   }, []);
 
   useEffect(() => {
-    breatheTimeoutRef.current = setTimeout(() => breathe(settings), 4000);
+    breatheTimeoutRef.current = setTimeout(() => breathe(settings.phases), 4000);
     return () => clearBreathTimeout();
   }, [breathe, clearBreathTimeout]);
 
@@ -119,18 +110,21 @@ export default function App() {
         firstCycleRef.current = true;
       } else {
         clearBreathTimeout();
-        breatheTimeoutRef.current = setTimeout(() => breathe(settings), 4000);
+        breatheTimeoutRef.current = setTimeout(
+          () => breathe(settings.phases),
+          4000,
+        );
       }
     }
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [settings, breathe, clearBreathTimeout]);
+  }, [settings.phases, breathe, clearBreathTimeout]);
 
   // Set background accent color based on phase
   useEffect(() => {
-    if (playful.dynamicColorsEnabled && phaseIndex >= 0) {
+    if (settings.dynamicColorsEnabled && phaseIndex >= 0) {
       const color = PHASE_COLORS[phaseIndex % PHASE_COLORS.length];
       // Convert hex to rgba with low opacity for ambient bg
       const r = parseInt(color.slice(1, 3), 16);
@@ -146,32 +140,25 @@ export default function App() {
         "rgba(135, 206, 235, 0.06)",
       );
     }
-  }, [phaseIndex, playful.dynamicColorsEnabled]);
+  }, [phaseIndex, settings.dynamicColorsEnabled]);
 
-  function handleSettingsChange(newSettings: Setting[]) {
-    setSettings(newSettings);
-    if (user) saveUserSettings(user.uid, { settings: newSettings });
-    clearBreathTimeout();
-    setCycleCount(0);
-    setPhaseIndex(-1);
-    firstCycleRef.current = true;
-    breathe(newSettings);
-  }
-
-  function handlePlayfulChange(newPlayful: PlayfulSettings) {
-    setPlayful(newPlayful);
-    savePlayfulSettings(newPlayful);
-    if (user) saveUserSettings(user.uid, { playfulSettings: newPlayful });
-  }
+  const handleSettingsChange = useCallback(
+    (next: AppSettings) => {
+      setSettings(next);
+      saveAppSettings(next);
+      if (user) saveUserSettings(user.uid, next);
+      clearBreathTimeout();
+      setCycleCount(0);
+      setPhaseIndex(-1);
+      firstCycleRef.current = true;
+      breathe(next.phases);
+    },
+    [user, breathe, clearBreathTimeout],
+  );
 
   return (
     <>
-      <SideMenu
-        settings={settings}
-        onSettingsChange={handleSettingsChange}
-        playfulSettings={playful}
-        onPlayfulChange={handlePlayfulChange}
-      />
+      <SideMenu settings={settings} onSettingsChange={handleSettingsChange} />
       <div
         id="main-view"
         onTouchMove={(e) => e.preventDefault()}
@@ -181,11 +168,11 @@ export default function App() {
           transition={circleTransition}
           phaseIndex={phaseIndex}
           cycleCount={cycleCount}
-          dynamicColorsEnabled={playful.dynamicColorsEnabled}
+          dynamicColorsEnabled={settings.dynamicColorsEnabled}
         />
         <BreathingText text={text} />
         <CycleCounter cycleCount={cycleCount} phaseIndex={phaseIndex} />
-        <Particles trigger={cycleCount} enabled={playful.particlesEnabled} />
+        <Particles trigger={cycleCount} enabled={settings.particlesEnabled} />
       </div>
     </>
   );

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -1,36 +1,30 @@
 import { useState, useRef, useEffect } from "react";
 import NoSleep from "nosleep.js";
 import { Button, Drawer, DrawerSize, Switch } from "@blueprintjs/core";
-import {
-  Setting,
-  PlayfulSettings,
-  DEFAULT_SETTINGS,
-  loadNoSleepEnabled,
-  saveNoSleepEnabled,
-} from "../types";
+import { AppSettings, Setting, DEFAULT_APP_SETTINGS } from "../types";
 import { useAuth } from "../auth/AuthContext";
 import "./SideMenu.scss";
 
 interface SideMenuProps {
-  settings: Setting[];
-  onSettingsChange: (newSettings: Setting[]) => void;
-  playfulSettings: PlayfulSettings;
-  onPlayfulChange: (settings: PlayfulSettings) => void;
+  settings: AppSettings;
+  onSettingsChange: (settings: AppSettings) => void;
 }
+
+type PlayfulKey = keyof Pick<
+  AppSettings,
+  "soundEnabled" | "particlesEnabled" | "dynamicColorsEnabled"
+>;
 
 export default function SideMenu({
   settings,
   onSettingsChange,
-  playfulSettings,
-  onPlayfulChange,
 }: SideMenuProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [noSleepEnabled, setNoSleepEnabled] = useState(loadNoSleepEnabled);
-  const [formSettings, setFormSettings] = useState<Setting[]>(settings);
+  const [formPhases, setFormPhases] = useState<Setting[]>(settings.phases);
 
   useEffect(() => {
-    setFormSettings(settings);
-  }, [settings]);
+    setFormPhases(settings.phases);
+  }, [settings.phases]);
   const [authError, setAuthError] = useState<string | null>(null);
   const [authBusy, setAuthBusy] = useState(false);
 
@@ -38,25 +32,33 @@ export default function SideMenu({
     useAuth();
 
   const noSleepRef = useRef<NoSleep | null>(null);
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
 
   useEffect(() => {
     noSleepRef.current = new NoSleep();
-    if (noSleepEnabled) {
-      Promise.resolve(noSleepRef.current.enable()).catch(() => {
-        setNoSleepEnabled(false);
-        saveNoSleepEnabled(false);
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    const ns = noSleepRef.current;
+    if (!ns) return;
+    if (settings.noSleepEnabled) {
+      Promise.resolve(ns.enable()).catch(() => {
+        const s = settingsRef.current;
+        onSettingsChange({ ...s, noSleepEnabled: false });
+      });
+    } else {
+      ns.disable();
+    }
+  }, [settings.noSleepEnabled, onSettingsChange]);
 
   function closeDrawer() {
     window.scrollTo(0, 0);
     setDrawerOpen(false);
   }
 
-  function saveSettings() {
-    const newSettings: Setting[] = formSettings.map(([word, time], i) => {
+  function savePhaseSettings() {
+    const newPhases: Setting[] = formPhases.map(([word, time], i) => {
       let t = Number(time);
       let w = word;
       if (t <= 0 && i % 2 === 1) {
@@ -67,29 +69,22 @@ export default function SideMenu({
       if (t > 10) t = 10;
       return [w, t];
     });
-    setFormSettings(newSettings);
-    window.localStorage.setItem("settings", JSON.stringify(newSettings));
-    onSettingsChange(newSettings);
+    setFormPhases(newPhases);
+    onSettingsChange({ ...settings, phases: newPhases });
     closeDrawer();
   }
 
-  function resetSettings() {
-    setFormSettings(DEFAULT_SETTINGS);
-    window.localStorage.setItem("settings", JSON.stringify(DEFAULT_SETTINGS));
-    onSettingsChange(DEFAULT_SETTINGS);
+  function resetPhaseSettings() {
+    setFormPhases(DEFAULT_APP_SETTINGS.phases);
+    onSettingsChange({
+      ...settings,
+      phases: DEFAULT_APP_SETTINGS.phases,
+    });
     closeDrawer();
   }
 
   function toggleNoSleep() {
-    if (noSleepEnabled) {
-      noSleepRef.current?.disable();
-      setNoSleepEnabled(false);
-      saveNoSleepEnabled(false);
-    } else {
-      noSleepRef.current?.enable();
-      setNoSleepEnabled(true);
-      saveNoSleepEnabled(true);
-    }
+    onSettingsChange({ ...settings, noSleepEnabled: !settings.noSleepEnabled });
     closeDrawer();
   }
 
@@ -98,7 +93,7 @@ export default function SideMenu({
     field: "word" | "time",
     value: string,
   ) {
-    setFormSettings((prev) => {
+    setFormPhases((prev) => {
       const next: Setting[] = prev.map(([w, t]) => [w, t]);
       if (field === "word") {
         next[index][0] = value;
@@ -109,8 +104,8 @@ export default function SideMenu({
     });
   }
 
-  function handlePlayfulToggle(key: keyof PlayfulSettings) {
-    onPlayfulChange({ ...playfulSettings, [key]: !playfulSettings[key] });
+  function handlePlayfulToggle(key: PlayfulKey) {
+    onSettingsChange({ ...settings, [key]: !settings[key] });
   }
 
   async function handleSignIn() {
@@ -183,7 +178,7 @@ export default function SideMenu({
                           id={`phase-word-${phase.label}`}
                           type="text"
                           name="word"
-                          value={formSettings[i][0]}
+                          value={formPhases[i][0]}
                           placeholder={phase.label}
                           onChange={(e) =>
                             handleFormChange(i, "word", e.target.value)
@@ -203,7 +198,7 @@ export default function SideMenu({
                           name="time"
                           min={phase.minTime}
                           max="10"
-                          value={formSettings[i][1]}
+                          value={formPhases[i][1]}
                           onChange={(e) =>
                             handleFormChange(i, "time", e.target.value)
                           }
@@ -213,7 +208,7 @@ export default function SideMenu({
                   ))}
                   <tr>
                     <td>
-                      <Button name="reset" onClick={resetSettings}>
+                      <Button name="reset" onClick={resetPhaseSettings}>
                         reset
                       </Button>
                     </td>
@@ -221,7 +216,7 @@ export default function SideMenu({
                       <Button
                         name="save"
                         intent="primary"
-                        onClick={saveSettings}
+                        onClick={savePhaseSettings}
                       >
                         save
                       </Button>
@@ -234,19 +229,21 @@ export default function SideMenu({
               <h3 className="menu-heading">Extras</h3>
               <div className="extras-toggles">
                 <Switch
-                  checked={playfulSettings.soundEnabled}
+                  checked={settings.soundEnabled}
                   label="Sound effects"
                   onChange={() => handlePlayfulToggle("soundEnabled")}
                 />
                 <Switch
-                  checked={playfulSettings.particlesEnabled}
+                  checked={settings.particlesEnabled}
                   label="Celebrations"
                   onChange={() => handlePlayfulToggle("particlesEnabled")}
                 />
                 <Switch
-                  checked={playfulSettings.dynamicColorsEnabled}
+                  checked={settings.dynamicColorsEnabled}
                   label="Color shifts"
-                  onChange={() => handlePlayfulToggle("dynamicColorsEnabled")}
+                  onChange={() =>
+                    handlePlayfulToggle("dynamicColorsEnabled")
+                  }
                 />
               </div>
             </li>
@@ -304,7 +301,7 @@ export default function SideMenu({
               <Button
                 id="noSleepToggle"
                 minimal
-                icon={noSleepEnabled ? "tick" : undefined}
+                icon={settings.noSleepEnabled ? "tick" : undefined}
                 onClick={toggleNoSleep}
               >
                 Prevent Display Sleep

--- a/src/firestore.ts
+++ b/src/firestore.ts
@@ -1,46 +1,91 @@
 import { doc, getDoc, setDoc } from "firebase/firestore";
 import { db } from "./firebase";
-import type { Setting, PlayfulSettings } from "./types";
+import type { AppSettings, Setting } from "./types";
+import { DEFAULT_APP_SETTINGS, normalizeAppSettings } from "./types";
 
 interface PhaseDoc {
   word: string;
   duration: number;
 }
 
-interface UserDoc {
+/** Serialized shape stored under `appSettings` on the user document */
+interface AppSettingsDoc {
+  phases: PhaseDoc[];
+  soundEnabled: boolean;
+  particlesEnabled: boolean;
+  dynamicColorsEnabled: boolean;
+  noSleepEnabled: boolean;
+}
+
+/** Legacy Firestore user document fields */
+interface LegacyUserDoc {
+  appSettings?: AppSettingsDoc;
   settings?: PhaseDoc[];
-  playfulSettings?: PlayfulSettings;
+  playfulSettings?: Partial<
+    Pick<
+      AppSettings,
+      "soundEnabled" | "particlesEnabled" | "dynamicColorsEnabled"
+    >
+  >;
 }
 
-export interface UserSettings {
-  settings?: Setting[];
-  playfulSettings?: PlayfulSettings;
-}
-
-function serializeSettings(settings: Setting[]): PhaseDoc[] {
+function serializePhases(settings: Setting[]): PhaseDoc[] {
   return settings.map(([word, duration]) => ({ word, duration }));
 }
 
-function deserializeSettings(phases: PhaseDoc[]): Setting[] {
+function deserializePhases(phases: PhaseDoc[]): Setting[] {
   return phases.map(({ word, duration }) => [word, duration]);
 }
 
-export async function loadUserSettings(uid: string): Promise<UserSettings | null> {
-  if (!db) return null;
-  const snap = await getDoc(doc(db, "users", uid));
-  if (!snap.exists()) return null;
-  const data = snap.data() as UserDoc;
+function serializeAppSettings(s: AppSettings): AppSettingsDoc {
   return {
-    settings: data.settings ? deserializeSettings(data.settings) : undefined,
-    playfulSettings: data.playfulSettings,
+    phases: serializePhases(s.phases),
+    soundEnabled: s.soundEnabled,
+    particlesEnabled: s.particlesEnabled,
+    dynamicColorsEnabled: s.dynamicColorsEnabled,
+    noSleepEnabled: s.noSleepEnabled,
   };
 }
 
-export async function saveUserSettings(uid: string, data: Partial<UserSettings>): Promise<void> {
+function deserializeAppSettings(doc_: AppSettingsDoc): AppSettings {
+  return normalizeAppSettings({
+    phases: deserializePhases(doc_.phases),
+    soundEnabled: doc_.soundEnabled,
+    particlesEnabled: doc_.particlesEnabled,
+    dynamicColorsEnabled: doc_.dynamicColorsEnabled,
+    noSleepEnabled: doc_.noSleepEnabled,
+  });
+}
+
+export async function loadUserSettings(
+  uid: string,
+): Promise<AppSettings | null> {
+  if (!db) return null;
+  const snap = await getDoc(doc(db, "users", uid));
+  if (!snap.exists()) return null;
+  const data = snap.data() as LegacyUserDoc;
+  if (data.appSettings) {
+    return deserializeAppSettings(data.appSettings);
+  }
+  const phases = data.settings
+    ? deserializePhases(data.settings)
+    : DEFAULT_APP_SETTINGS.phases;
+  const playful = data.playfulSettings ?? {};
+  return normalizeAppSettings({
+    phases,
+    ...playful,
+    noSleepEnabled: DEFAULT_APP_SETTINGS.noSleepEnabled,
+  });
+}
+
+export async function saveUserSettings(
+  uid: string,
+  settings: AppSettings,
+): Promise<void> {
   if (!db) return;
-  const doc_ = doc(db, "users", uid);
-  const payload: Partial<UserDoc> = {};
-  if (data.settings) payload.settings = serializeSettings(data.settings);
-  if (data.playfulSettings) payload.playfulSettings = data.playfulSettings;
-  await setDoc(doc_, payload, { merge: true });
+  await setDoc(
+    doc(db, "users", uid),
+    { appSettings: serializeAppSettings(settings) },
+    { merge: true },
+  );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,60 +1,103 @@
 export type Setting = [string, number];
 
-export const DEFAULT_SETTINGS: Setting[] = [
-  ["inhale", 4],
-  ["hold", 4],
-  ["exhale", 4],
-  ["pause", 4],
-];
-
-export function loadSettings(): Setting[] {
-  try {
-    const saved = window.localStorage.getItem("settings");
-    if (saved !== null) return JSON.parse(saved) as Setting[];
-  } catch (e) {
-    // ignore
-  }
-  return DEFAULT_SETTINGS;
-}
-
-export interface PlayfulSettings {
+export interface AppSettings {
+  phases: Setting[];
   soundEnabled: boolean;
   particlesEnabled: boolean;
   dynamicColorsEnabled: boolean;
+  noSleepEnabled: boolean;
 }
 
-export const DEFAULT_PLAYFUL: PlayfulSettings = {
+export const DEFAULT_APP_SETTINGS: AppSettings = {
+  phases: [
+    ["inhale", 4],
+    ["hold", 4],
+    ["exhale", 4],
+    ["pause", 4],
+  ],
   soundEnabled: false,
   particlesEnabled: true,
   dynamicColorsEnabled: true,
+  noSleepEnabled: false,
 };
 
-export function loadPlayfulSettings(): PlayfulSettings {
+const STORAGE_KEY = "appSettings";
+
+export function normalizeAppSettings(partial: Partial<AppSettings>): AppSettings {
+  const phases =
+    partial.phases &&
+    Array.isArray(partial.phases) &&
+    partial.phases.length === DEFAULT_APP_SETTINGS.phases.length
+      ? partial.phases
+      : DEFAULT_APP_SETTINGS.phases;
+  return {
+    ...DEFAULT_APP_SETTINGS,
+    ...partial,
+    phases,
+  };
+}
+
+function migrateLegacyLocalStorage(): AppSettings {
+  let phases = DEFAULT_APP_SETTINGS.phases;
   try {
-    const saved = window.localStorage.getItem("playfulSettings");
-    if (saved !== null) return { ...DEFAULT_PLAYFUL, ...JSON.parse(saved) };
-  } catch (e) {
+    const old = window.localStorage.getItem("settings");
+    if (old !== null) {
+      const parsed = JSON.parse(old) as Setting[];
+      if (Array.isArray(parsed) && parsed.length === phases.length) {
+        phases = parsed;
+      }
+    }
+  } catch {
     // ignore
   }
-  return DEFAULT_PLAYFUL;
-}
-
-export function savePlayfulSettings(settings: PlayfulSettings) {
-  window.localStorage.setItem("playfulSettings", JSON.stringify(settings));
-}
-
-export function loadNoSleepEnabled(): boolean {
+  let soundEnabled = DEFAULT_APP_SETTINGS.soundEnabled;
+  let particlesEnabled = DEFAULT_APP_SETTINGS.particlesEnabled;
+  let dynamicColorsEnabled = DEFAULT_APP_SETTINGS.dynamicColorsEnabled;
   try {
-    const saved = window.localStorage.getItem("noSleepEnabled");
-    if (saved !== null) return JSON.parse(saved) as boolean;
-  } catch (e) {
+    const oldPlayful = window.localStorage.getItem("playfulSettings");
+    if (oldPlayful !== null) {
+      const p = JSON.parse(oldPlayful) as Partial<AppSettings>;
+      if (typeof p.soundEnabled === "boolean") soundEnabled = p.soundEnabled;
+      if (typeof p.particlesEnabled === "boolean") particlesEnabled = p.particlesEnabled;
+      if (typeof p.dynamicColorsEnabled === "boolean") {
+        dynamicColorsEnabled = p.dynamicColorsEnabled;
+      }
+    }
+  } catch {
     // ignore
   }
-  return false;
+  let noSleepEnabled = DEFAULT_APP_SETTINGS.noSleepEnabled;
+  try {
+    const oldNs = window.localStorage.getItem("noSleepEnabled");
+    if (oldNs !== null) noSleepEnabled = JSON.parse(oldNs) as boolean;
+  } catch {
+    // ignore
+  }
+  const merged = normalizeAppSettings({
+    phases,
+    soundEnabled,
+    particlesEnabled,
+    dynamicColorsEnabled,
+    noSleepEnabled,
+  });
+  saveAppSettings(merged);
+  return merged;
 }
 
-export function saveNoSleepEnabled(enabled: boolean) {
-  window.localStorage.setItem("noSleepEnabled", JSON.stringify(enabled));
+export function loadAppSettings(): AppSettings {
+  try {
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    if (saved !== null) {
+      return normalizeAppSettings(JSON.parse(saved) as Partial<AppSettings>);
+    }
+  } catch {
+    // ignore
+  }
+  return migrateLegacyLocalStorage();
+}
+
+export function saveAppSettings(settings: AppSettings) {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
 }
 
 export const PHASE_COLORS = ["#87CEEB", "#A8D8EA", "#7EC8C8", "#B8A9C9"];


### PR DESCRIPTION
## Summary

Unifies breathing phase timings, sound/particles/color toggles, and the prevent-sleep preference into one `AppSettings` type and one persistence path.

## Changes

- **localStorage**: single key `appSettings`; first load migrates legacy `settings`, `playfulSettings`, and `noSleepEnabled`.
- **Firestore**: new `appSettings` document field; existing `settings` + `playfulSettings` are still read and merged for backward compatibility.
- **React**: one state object in `App`; `SideMenu` receives a single `settings` / `onSettingsChange` pair.

## Testing

- `npx tsc --noEmit` passes.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the persistence format and migration logic for user settings in both localStorage and Firestore, which could reset or mis-merge preferences if edge cases occur.
> 
> **Overview**
> **Consolidates all user preferences into a single `AppSettings` object** (breathing `phases`, sound/particles/color toggles, and `noSleepEnabled`), replacing the previous split between `settings`, `playfulSettings`, and a separate no-sleep flag.
> 
> Updates persistence to match: localStorage now reads/writes a single `appSettings` key with one-time migration from legacy keys, and Firestore now saves under `users/{uid}.appSettings` while still reading legacy `settings`/`playfulSettings` for backward compatibility.
> 
> Refactors `App` and `SideMenu` to pass/update one settings object, including reworking NoSleep enable/disable to be driven by `settings.noSleepEnabled` and restarting the breathing loop from `settings.phases` after changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a46b4a20138b48abcdf1507e6dc025308a27b06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->